### PR TITLE
ShrekTheThird: fix the black screen with no settings file (#77) and the 2D menu scale

### DIFF
--- a/source/fixes/ShrekTheThirdWidescreenFix/dllmain.cpp
+++ b/source/fixes/ShrekTheThirdWidescreenFix/dllmain.cpp
@@ -228,6 +228,121 @@ void WidescreenFix()
 			});
 		}
 
+		// The game does not create its device from the resolution globals above. It picks a
+		// mode out of a hardcoded 5-entry table ({width, height, 1} each, followed by the
+		// entry count) and the "resolution" value in its settings file is an index into it.
+		// The hooks above rewrite the globals, but the device is still built from the indexed
+		// table entry, so the two disagree and the frame comes out black - which is the
+		// black screen reported in issue #77.
+		//
+		// Rewriting the table makes the wanted mode a real member of the game's own list, so
+		// it is selected on every path, including the one taken when no settings file exists
+		// yet. It also gets past the resolution validator at exe+0x18F3C4, which resets any
+		// mode that is not in the list.
+		//
+		// All five entries are set: the index then cannot select a wrong one, so this works
+		// with no settings file at all. (Rewriting a single entry only works for the last
+		// one - the list appears to need ascending order.)
+		std::uint8_t* ResolutionModeTableScanResult = Memory::PatternScan(exeModule,
+			"80 02 00 00 E0 01 00 00 01 00 00 00 20 03 00 00 58 02 00 00 01 00 00 00 "
+			"00 04 00 00 00 03 00 00 01 00 00 00 00 05 00 00 00 04 00 00 01 00 00 00 "
+			"40 06 00 00 B0 04 00 00 01 00 00 00 05 00 00 00");
+		if (ResolutionModeTableScanResult)
+		{
+			spdlog::info("Resolution Mode Table Scan: Address is {:s}+{:x}", sExeName.c_str(), ResolutionModeTableScanResult - (std::uint8_t*)exeModule);
+
+			for (int i = 0; i < 5; ++i)
+			{
+				Memory::Write(ResolutionModeTableScanResult + (i * 12), iCurrentResX);
+				Memory::Write(ResolutionModeTableScanResult + (i * 12) + 4, iCurrentResY);
+			}
+		}
+		else
+		{
+			spdlog::error("Failed to locate resolution mode table memory address.");
+			return;
+		}
+
+		// 2D UI scale. The function holding the Res1 instruction derives the UI scale at its
+		// tail from its own stack arguments - the mode that was ASKED for - which the Res1
+		// hook never touches:
+		//
+		//   fild [esp+0x18] ; fmul [1/200] ; fstp [uiScaleX]      = width/200
+		//   fild [esp+0x0C] ; fmul [1/200] ; fstp [uiScaleY]      = height/200
+		//   fld  [uiScaleX] ; fmul [0.3125]; fstp [uiScaleZ]      = width/640
+		//
+		// Sizing the UI off the WIDTH means that on a 16:9 display the menu text is scaled
+		// for a 16:9 basis while the art is authored for 4:3, and it overflows. Worse, when
+		// no settings file exists the game asks for its small default, gets the right mode,
+		// and lays the menu out for the wrong one.
+		//
+		// The game already contains an unused override for this: at the scale function the
+		// pair below is tested, and if non-zero the scale is taken from it instead. Both live
+		// in .bss and nothing ever writes them, so the branch is always skipped. Setting them
+		// to a 4:3-proportioned canvas at the real screen height gives the proportion the art
+		// expects, and repointing the inline tail at the same globals keeps both writers in
+		// agreement.
+		std::uint8_t* UIScaleOverrideScanResult = Memory::PatternScan(exeModule,
+			"8B 0D ?? ?? ?? ?? 85 C9 74 1A DB 05 ?? ?? ?? ?? D8 0D ?? ?? ?? ?? D9 1D ?? ?? ?? ?? DB 05 ?? ?? ?? ?? EB 12");
+		std::uint8_t* UIScaleInlineScanResult = Memory::PatternScan(exeModule,
+			"DB 44 24 18 5F 5E 5D D8 0D ?? ?? ?? ?? B0 01 5B D9 1D ?? ?? ?? ?? DB 44 24 0C "
+			"D8 0D ?? ?? ?? ?? D9 1D ?? ?? ?? ?? D9 05 ?? ?? ?? ?? D8 0D ?? ?? ?? ?? "
+			"D9 1D ?? ?? ?? ?? 59 C2 08 00");
+		if (UIScaleOverrideScanResult && UIScaleInlineScanResult)
+		{
+			spdlog::info("UI Scale Override Scan: Address is {:s}+{:x}", sExeName.c_str(), UIScaleOverrideScanResult - (std::uint8_t*)exeModule);
+			spdlog::info("UI Scale Instructions Scan: Address is {:s}+{:x}", sExeName.c_str(), UIScaleInlineScanResult - (std::uint8_t*)exeModule);
+
+			std::uint32_t uiOverrideWidthAddress = *reinterpret_cast<std::uint32_t*>(UIScaleOverrideScanResult + 2);
+			std::uint32_t uiOverrideHeightAddress = *reinterpret_cast<std::uint32_t*>(UIScaleOverrideScanResult + 0x1E);
+
+			std::uint32_t fOneOver200Address = *reinterpret_cast<std::uint32_t*>(UIScaleInlineScanResult + 0x09);
+			std::uint32_t uiScaleXAddress = *reinterpret_cast<std::uint32_t*>(UIScaleInlineScanResult + 0x12);
+			std::uint32_t uiScaleYAddress = *reinterpret_cast<std::uint32_t*>(UIScaleInlineScanResult + 0x22);
+			std::uint32_t f0Point3125Address = *reinterpret_cast<std::uint32_t*>(UIScaleInlineScanResult + 0x2E);
+			std::uint32_t uiScaleZAddress = *reinterpret_cast<std::uint32_t*>(UIScaleInlineScanResult + 0x34);
+
+			// a 4:3-wide canvas at the real screen height
+			Memory::Write(uiOverrideWidthAddress, static_cast<int>((iCurrentResY * 4) / 3));
+			Memory::Write(uiOverrideHeightAddress, iCurrentResY);
+
+			// Rewrite the inline tail to read the same override. It is 60 bytes and is
+			// followed by 12 bytes of int3 alignment padding before the next function, so
+			// the 64-byte replacement fits without relocating anything.
+			std::uint8_t trampoline[64];
+			std::size_t n = 0;
+			auto emit = [&](std::uint8_t a, std::uint8_t b, std::uint32_t address)
+			{
+				trampoline[n++] = a;
+				trampoline[n++] = b;
+				*reinterpret_cast<std::uint32_t*>(trampoline + n) = address;
+				n += 4;
+			};
+			emit(0xDB, 0x05, uiOverrideWidthAddress);   // fild dword ptr [overrideWidth]
+			emit(0xD8, 0x0D, fOneOver200Address);       // fmul dword ptr [1/200]
+			emit(0xD9, 0x1D, uiScaleXAddress);          // fstp dword ptr [uiScaleX]
+			emit(0xDB, 0x05, uiOverrideHeightAddress);  // fild dword ptr [overrideHeight]
+			emit(0xD8, 0x0D, fOneOver200Address);       // fmul dword ptr [1/200]
+			emit(0xD9, 0x1D, uiScaleYAddress);          // fstp dword ptr [uiScaleY]
+			emit(0xD9, 0x05, uiScaleXAddress);          // fld  dword ptr [uiScaleX]
+			emit(0xD8, 0x0D, f0Point3125Address);       // fmul dword ptr [0.3125]
+			emit(0xD9, 0x1D, uiScaleZAddress);          // fstp dword ptr [uiScaleZ]
+			trampoline[n++] = 0x5F;                     // pop edi
+			trampoline[n++] = 0x5E;                     // pop esi
+			trampoline[n++] = 0x5D;                     // pop ebp
+			trampoline[n++] = 0xB0; trampoline[n++] = 0x01;  // mov al, 1
+			trampoline[n++] = 0x5B;                     // pop ebx
+			trampoline[n++] = 0x59;                     // pop ecx
+			trampoline[n++] = 0xC2; trampoline[n++] = 0x08; trampoline[n++] = 0x00;  // ret 8
+
+			Memory::PatchBytes(UIScaleInlineScanResult, trampoline, n);
+		}
+		else
+		{
+			spdlog::error("Failed to locate UI scale memory address(es).");
+			return;
+		}
+
 		std::uint8_t* CameraFOVInstructionScanResult = Memory::PatternScan(exeModule, "68 ?? ?? ?? ?? FF 52 ?? 8B 4C 24");
 		if (CameraFOVInstructionScanResult)
 		{


### PR DESCRIPTION
Fixes #77.

I filed that issue as "black screen on an install that has never written its `SHReK the THiRD.ini`". That framing turned out to be too narrow, so this PR explains the actual cause and fixes it, plus a second problem in the same function.

## 1. The black screen

The game does not create its device from the resolution globals the fix writes. It picks a mode out of a hardcoded 5-entry table in `.data`:

```
0x00766694:  {640,480,1} {800,600,1} {1024,768,1} {1280,1024,1} {1600,1200,1}
0x007666D0:  entry count (5)
```

and the `resolution` value in the settings file is an index into it. `Res1` rewrites the globals, but the device is still built from the indexed table entry. The two disagree and nothing draws.

The failure is the *mismatch*, not the resolution. Measured on a 2560x1440 display with the fix active:

| setup | globals | result |
|---|---|---|
| index 1, table untouched | 800x600 | black |
| desktop *also* set to 800x600 | 800x600 | renders (both agree) |
| table rewritten to 2560x1440 | 2560x1440 | renders at native res |

So a missing ini is only one way in. Another, which I hit on my own machine, is a **read-only save folder**: the game's save/load path compares `GetFileAttributes` for exact equality with `FILE_ATTRIBUTE_DIRECTORY`, and Windows marks user-profile folders read-only (`0x11`), so it ignores an existing settings file on load exactly as if it were absent. Any install whose saved index names a different mode than the fix targets hits it too.

This PR rewrites the mode table so the wanted mode is a real member of the game's own list. It is then selected on every path, including the one taken when no settings file exists, and it gets past the resolution validator at `exe+0x18F3C4` which resets any mode not in the list.

All five entries are set rather than one. That is deliberate: the index then cannot select a wrong entry, so it works with no settings file at all. Rewriting a single entry only works for the last one — putting the new resolution at index 1 makes the game fall back to 640x480 and render black, so the list appears to need ascending order.

The existing `Res1`/`Res2` hooks are left in place. With the table patched they write the same values the game now computes, so this change is additive and that is the configuration I tested.

## 2. The 2D menu scale

The function containing `Res1` derives the UI scale at its tail from its **own stack arguments**, which the `Res1` hook never touches:

```
fild [esp+0x18] ; fmul [1/200]  ; fstp [0x76D374]   uiScaleX = width/200
fild [esp+0x0C] ; fmul [1/200]  ; fstp [0x76D370]   uiScaleY = height/200
fld  [0x76D374] ; fmul [0.3125] ; fstp [0x76D36C]   uiScaleZ = width/640
```

Sizing the UI off the **width** means that on 16:9 the menu text is scaled for a 16:9 basis while the art is authored for 4:3, and it overflows the parchment. And when no settings file exists the game asks for its small default, receives the correct mode, and lays the menu out for the wrong one.

The game already contains an unused override for this. At `0x5B6190` a pair of globals is tested and, if non-zero, the scale is taken from them instead. Both live in `.bss` and are referenced by exactly three instructions in the whole image — nothing ever writes them, so the branch is always skipped.

This PR sets them to a 4:3-proportioned canvas at the real screen height, and repoints the inline tail at the same globals so both writers agree. Measured at 2560x1440:

```
4.0 / 7.2 / 12.8   width basis      text overflows the parchment
2.5 / 6.0 /  8.0   stale 1600x1200  text fits, scene cropped at both edges
3.0 / 7.2 /  9.6   height*4/3       correct
```

Both halves are needed — setting the override alone fixes the text but leaves the logo scaled wrong and pushed off the top-right, because the inline computation still wins for some elements.

The tail rewrite is 64 bytes over a 60-byte sequence followed by 12 bytes of `int3` alignment padding before the next function, so nothing is relocated.

## Testing

Verified on Windows 11 with an RTX 4070 Ti, on the two 2007 no-CD builds (3,603,269 and
3,608,576 bytes — identical code at identical VAs). Resolutions tested with this build:

| resolution | aspect | result |
|---|---|---|
| 1920x1080 | 16:9 | correct, with no settings file |
| 1920x1200 | 16:10 | correct, auto-detected from the desktop |
| 2560x1600 | 16:10 | correct |
| 3840x2160 | 16:9 | correct, with no settings file |

2560x1440 was also confirmed, via a separate implementation of the same three patches.

- No settings file at all: previously black, now renders correctly at native resolution with a correctly laid-out menu.
- Existing settings file: unchanged, still correct.
- Intro/loading screens and in-game HUD checked — HUD elements stay anchored to their corners at correct size, nothing clipped or stretched.

## Things worth knowing before merging

- **The Options resolution list now shows five identical entries.** That is the cost of setting all five. Defensible for a fix that overrides the resolution anyway, but it is a visible change.
- **Not tested on retail (SecuROM).** Its `.text` is encrypted on disk and only unpacked after `DLL_PROCESS_ATTACH`, so the existing pattern scans cannot resolve there either — this PR does not change that. The mode table is in `.data` and is not encrypted.
- **Not tested at ultrawide (21:9) or on a 4:3 display.** 16:10 is covered by the 2560x1600 run above. The `height*4/3` basis should hold for anything wider than 4:3 and is a no-op at 4:3, but I have not measured either case.
- The end-of-level quest screen has a separate, unrelated defect where the checkmark overlays sit on top of the quest text. It is positioned from UI layout data in `menu_end_game.res`, not from any of these globals, and is untouched here.

Happy to split this into two PRs, drop the mode-table half, or adjust anything to taste.


